### PR TITLE
fix for the name of the company that does conda

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -12,7 +12,7 @@ Installation
 Obtain Anaconda
 ===============
 
-Go grab a copy of the `Anaconda <https://www.continuum.io/downloads>`_ distribution from Continuum, Inc. Be sure to select
+Go grab a copy of the `Anaconda <https://www.continuum.io/downloads>`_ distribution from Continuum Analytics, Inc. Be sure to select
 the installation medium appropriate for your operating system and architecture.
 
 Installation instructions for your platform are also available on the download page.


### PR DESCRIPTION
Admittedly, this is very pendantic, but nevertheless... The actual name of the company that does conda is "Continuum Analytics", not just "Continuum"