### PR TITLE
Clarity continued

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -61,6 +61,27 @@ Please reinstall Miniconda (or Anaconda) from scratch. AstroConda uses ``source 
 
 To clarify, installing AstroConda packages directly into the 'root' may cause Miniconda (or Anaconda) itself to be come unstable. In addition to this, removing packages from this environment is tedious and will likely break your Anaconda installation if you are not careful. *Reinstalling from scratch is the safest option.*
 
+How do I reinstall Miniconda?
+=============================
+
+This assumes Miniconda3 has been installed to the default location (``/home/username/miniconda3``). We will refer to your home directory as ``~/`` from here on.
+
+.. code-block:: sh
+
+    # Make a backup of your existing installation if desired:
+    $ tar cfz /safe/place/miniconda3_OLD.tar.gz ~/miniconda3
+
+    # Remove miniconda3
+    $ rm -rf ~/miniconda3
+
+    # Download the Miniconda3 installer for your platform from: http://conda.pydata.org/miniconda.html
+
+    # Execute the installer (where PLATFORM is one of Linux or MacOSX)
+    $ bash /path/to/Miniconda3-latest-PLATFORM-x86_64.sh
+
+The installer may offer to automatically edit ``~/.bash_profile`` and prepend ``~/miniconda3/bin`` to your ``PATH``. If you already have this entry in your ``PATH``, simply reponse with 'no'. Responding with 'yes' will add another entry even if it exists resuling in a ``PATH`` that looks much like: ``~/miniconda3/bin:~/miniconda3/bin:[...]``.
+
+
 Why am I being prompted by NumPy/SciPy with a MKL 30-day trial warning?
 =======================================================================
 

--- a/source/updating.rst
+++ b/source/updating.rst
@@ -9,8 +9,8 @@ Updating AstroConda
 
 There are few simple ways to update packages obtained from AstroConda:
 
-Updating the Release
---------------------
+Updating
+--------
 
 .. code-block:: sh
 
@@ -41,6 +41,18 @@ Updating Packages Individually
 
 If you are interested in receiving updates for a particular package, then this method is for you. Be aware that packages may depend on other packages, so the total list of package updates returned by this command will vary.
 
+
+General Maintenance
+===================
+
+.. code-block:: sh
+
+    $ source deactivate
+    $ conda update --all
+
+Keeping AstroConda up to date is important, but not nearly as important as keeping your 'root' (i.e. the base installation) updated as well. ``conda`` is like any other software project and it requires periodic refreshing to stay current with the latest changes. Failing to do this can (over time) cause side-effects such as, the inability to upgrade, install, remove, or search for packages.
+
+However, updating extremely old releases of ``conda`` to the latest version have been known to break Miniconda due to a variety of API changes in the code. If this happens to you, reinstalling Miniconda and regenerating your AstroConda environment is the fastest way to resolve the problem. Refer to the `FAQ <faq.html#how-do-i-reinstall-miniconda>`_ for more details.
 
 Downgrading Packages
 ====================


### PR DESCRIPTION
This PR addresses a few long standing issues. First, we never had a FAQ entry to describe the reinstallation procedure for the base installation, nor did we attempt to nudge the user to keep their base installation up to date.