### PR TITLE
Gemini IRAF release changes

### DIFF
--- a/source/compat.rst
+++ b/source/compat.rst
@@ -15,15 +15,15 @@ These versions of the conda package and environment management tool itself are k
 | 4.1.6                      |
 +----------------------------+
 
-If you have an indicated version of conda installed you may want to upgrade to a newer version with 
+If you have an indicated version of conda installed you may want to upgrade to a newer version with
 
 ``conda update conda``
 
 Once completed, check that the newly installed version is not indicated above as a problematic version. If it is indicated, you may have to downgrade to a previous version of conda in order to obtain one that has not been identified problematic.
 
-``conda search conda`` 
+``conda search conda``
 
-will display a list of all versions of conda available. Select a version from the search list that does not appear in the table above and run 
+will display a list of all versions of conda available. Select a version from the search list that does not appear in the table above and run
 
 ``conda install conda=<version>``.
 
@@ -34,7 +34,31 @@ If you spot a compatibility problem not listed here please let us know by sendin
 .. note::
 
   **You may be affected by an issue if you have updated your AstroConda environment on or after the dates listed in each section below.**
-  
+
+2017-05-24
+==========
+
+The method used to install IRAF via AstroConda has changed!
+
+Before today, AstroConda's ``iraf`` package provided a full IRAF installation in a single tarball. Not only did this take a long time to install, it has proven to be problematic, because updating even one line of code required us to repackage >700MBs of data. As of now, IRAF has been split into several smaller packages (``iraf.[pkg]``) and controlled via a single meta-package: ``iraf-all``.  The new ``pyraf-all`` meta-package installs ``pyraf`` along with packages identified to require ``pyraf`` and ``iraf``. The installation section, :ref:`iraf_install`, has been updated to reflect the changes detailed below.
+
+To install a new IRAF environment:
+
+.. code-block:: sh
+
+    $ conda create -n iraf27 python=2.7 iraf-all pyraf-all stsci
+    $ source activate iraf27
+
+If you plan to update an existing "iraf27" environment, do the following:
+
+.. code-block:: sh
+
+    $ conda install -n iraf27 iraf-all pyraf-all
+    $ source activate iraf27
+
+``conda update`` will not work as expected in this case, due to the fact that the ``iraf`` package no longer serves the same purpose. After ``iraf-all`` has been installed you may continue to use ``conda update --all`` to perform general updates.
+
+
 2017-05-19
 ==========
 
@@ -50,8 +74,8 @@ operational HST calibration pipeline build, HSTDP 2017.2
     >>> sdq = stpyfits.getdata("j9ot10icq_raw.fits", extname="DQ", extver=1)
     WARNING: AstropyDeprecationWarning: The NumCode class attribute is deprecated and may be removed in a future version.
         Use the module level constant BITPIX2DTYPE instead. [astropy.utils.decorators]
-  
-2017-05-02  
+
+2017-05-02
 ==========
 
 A collection of errant release candidate packages were published to the AstroConda public channel (http://ssb.stsci.edu/astroconda) on Friday, Apr 28, 2017 around 3:45pm and remained available for download until 10:30am on Tuesday, May 2, 2017. If you updated/upgraded any of the following packages during that window, you may have retrieved and installed software which is unsuitable for use due to untested behavior.

--- a/source/getting_started.rst
+++ b/source/getting_started.rst
@@ -64,20 +64,3 @@ Now append **one of the following** ``export`` commands that best matches the ou
 
 At this point, to assume the new environment with ``conda`` in your ``PATH``, open a new terminal or execute ``source ~/.bash_profile`` and continue on to :ref:`configure_astroconda_channel`.
 
-.. _configure_astroconda_channel:
-
-Configure Conda to use the Astroconda Channel
-=============================================
-
-In order to install packages directly from the AstroConda channel you will need to append our URL to Conda's channel search path.
-
-.. code-block:: sh
-
-    $ conda config --add channels http://ssb.stsci.edu/astroconda
-    # Writes changes to ~/.condarc
-
-Be aware that indiscriminately adding channels to your configuration, be it from `anaconda.org <https://anaconda.org>`_ or via direct-URL can effect the stability of software packages in your run-time environment.
-
-For example, if you add a channel found on anaconda.org because it contains a software package you're interested in, but it too provides the same software found in AstroConda, it's possible you may lose track of where packages are coming from. Or worse, the software you installed from the other channel was built incorrectly or did not account for a special case, so now the packages in your environment relying on this as a dependency could very well cease to function correctly.
-
-If you decide to have multiple channels defined in your configuration and bugs begin to appear, it may be best to check their origin before issuing a support ticket to help@stsci.edu. ``conda list`` can be used to display such information about the packages installed in your environment.

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -15,6 +15,19 @@ A "stack" is a collection of software designed to target the various use cases o
     - The data processing environment used by STScI operations and instrument teams
     - Python 3.x only
 
+.. _configure_astroconda_channel:
+
+
+Configure Conda to use the Astroconda Channel
+=============================================
+
+In order to install packages directly from the AstroConda channel you will need to append our URL to Conda's channel search path.
+
+.. code-block:: sh
+
+    $ conda config --add channels http://ssb.stsci.edu/astroconda
+    # Writes changes to ~/.condarc
+
 
 .. _standard_install:
 
@@ -49,8 +62,7 @@ Legacy Software Stack (with IRAF)
 
 The maintainers of the AstroConda channel have limited resources to support :abbr:`IRAF (Image Reduction and Analysis Facility)`, but users that require the ability to run IRAF and PyRAF tasks may want to install it via AstroConda. For help with any issues that come up during installation or use, please visit the `PyRAF FAQ <http://www.stsci.edu/institute/software_hardware/pyraf/pyraf_faq>`_. **Linux users** please be sure to visit `this FAQ entry <faq.html#in-linux-how-do-i-install-iraf-s-32-bit-dependencies>`_ for a quick guide to installing IRAF's 32-bit dependencies.
 
-
-The package management system, Conda, is now configured to pull from our repository, so you may go ahead and install the ``stsci`` package, as well as ``pyraf``, and finally ``iraf``. The ``stsci`` package installs nearly all of the software provided by STScI in one shot, however if you prefer a slimmed down IRAF/PyRAF experience, feel free to omit it.
+The package management system, Conda, is now configured to pull from our repository, so you may go ahead and install the ``iraf-all`` package, as well as ``pyraf-all``, and finally ``stsci``. The ``stsci`` package installs nearly all of the software provided by STScI in one shot, however if you prefer a slimmed down IRAF/PyRAF experience, feel free to omit it.
 
 Due to Python 3.x incompatibilities present in several tasks, it is recommended to install IRAF alongside Python 2.7.
 
@@ -58,7 +70,7 @@ The following example generates a new conda environment named "iraf27", however 
 
 .. code-block:: sh
 
-    $ conda create -n iraf27 python=2.7 stsci pyraf iraf
+    $ conda create -n iraf27 python=2.7 iraf-all pyraf-all stsci
 
 After the installation is complete go ahead and activate the "iraf27" environment. This command only needs to be executed one time per terminal session.
 

--- a/source/updating.rst
+++ b/source/updating.rst
@@ -14,7 +14,7 @@ Updating via Metapackage
 
     $ conda update -n astroconda stsci
 
-This is best used by individuals that favor software stability over receiving the "bleeding edge". Remember, updating the ``stsci`` package only effects packages part of the **official release** of our software. Packages provided by the AstroConda channel, but are not controlled by the ``stsci`` package **will not receive updates**. This is true for other packages as well (e.g. stsci-hst, stsci-data-analysis, etc).
+This is best used by individuals that favor software stability over receiving the "bleeding edge". Remember, updating the ``stsci`` package only effects packages part of the **official release** of our software. Packages provided by the AstroConda channel, but are not controlled by the ``stsci`` package **will not receive updates**. This is true for other packages as well (e.g. ``stsci-hst``, ``stsci-data-analysis``, etc).
 
 To clarify what this does, if the ``stsci`` package (used to create your environment) has not been updated by STScI to accommodate recently added packages, or newer versions of those packages, nothing will be updated in your environment on behalf of ``stsci``. In general, to receive interim bug fix releases please consider updating all packages, or individual packages of interest.
 


### PR DESCRIPTION
- Moved configuration of astroconda channel to software stack page
- Minor formatting changes
- Stripped whitespace added by several past commits
- Changed package references in IRAF's installation instructions
- Added blurb to the compatibility page.

cc @jehturner @rendinam @stsci-hack 