### PR TITLE
2017.2

### DIFF
--- a/source/compat.rst
+++ b/source/compat.rst
@@ -35,6 +35,7 @@ If you spot a compatibility problem not listed here please let us know by sendin
 
   **You may be affected by an issue if you have updated your AstroConda environment on or after the dates listed in each section below.**
 
+
 2017-05-24
 ==========
 
@@ -138,7 +139,7 @@ Alternative user action:
 AstroPy v1.3 fully deprecated calls to ``astropy.io.fits.new_table``.
 The following packages are known to be incompatible with this release:
 
-  * ``calcos <= 3.1.8`` - Bugfix pending
+  * ``calcos <= 3.1.8`` - 3.2.1 released (Jul 06, 2017)
   * ``costools <= 1.2.1`` - Bugfix pending
   * ``fitsblender <= 0.2.6`` - 0.3.0 released (Jan 17, 2017)
 

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -68,6 +68,17 @@ Linux     3.5     http://ssb.stsci.edu/conda/hstdp-2016.2/hstdp-2016.2-linux-py3
 OS X      3.5     http://ssb.stsci.edu/conda/hstdp-2016.2/hstdp-2016.2-osx-py35.2.txt
 ========  ======  ===
 
+2017.2
+++++++
+
+========  ======  ===
+PLATFORM  Python  URL
+========  ======  ===
+Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-linux-py35.final.txt
+OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-osx-py35.final.txt
+========  ======  ===
+
+
 Release Schema
 ==============
 
@@ -75,12 +86,12 @@ If you wish to write shell scripts to manage your local pipeline installations, 
 
 .. code-block:: sh
 
-    RELEASE_HOME=http://ssb.stsci.edu/conda
+    RELEASE_HOME=http://ssb.stsci.edu/releases
 
     #               hstdp 2016  1
     #               ^     ^     ^
     RELEASE_PARENT=$NAME-$YEAR.$BUILD
 
-    #                              linux     py35            2
+    #                              linux     py35            final|post#
     #                              ^         ^               ^
     RELEASE_CHILD=$RELEASE_PARENT-$PLATFORM-$PYTHON_VERSION.$ITERATION.txt

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -82,7 +82,7 @@ OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-osx-py
 Continuous Integration
 ======================
 
-This example BASH function is provides a starting point for users intending to execute pipeline software from within a continuous integration environment. This installation method is unsupported and your mileage may vary. Use at your own risk.
+This example BASH function provides a starting point for users intending to execute pipeline software from within a continuous integration environment. This installation method is unsupported and your mileage may vary. Use at your own risk.
 
 .. code-block:: sh
 

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -82,7 +82,7 @@ OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-osx-py
 Continuous Integration
 ======================
 
-This example BASH function is provided as a starting point for advanced users hooking our pipeline(s) into their continuous integration environment. This installation method is unsupported and your mileage may vary. Use at your own risk.
+This example BASH function is provided as a starting point for advanced users hooking up pipeline(s) in their continuous integration environments. This installation method is unsupported and your mileage may vary. Use at your own risk.
 
 .. code-block:: sh
 

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -54,8 +54,8 @@ HST Data Processing (HSTDP)
 ========  ======  ===
 PLATFORM  Python  URL
 ========  ======  ===
-Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-linux-py35.2.txt
-OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-osx-py35.2.txt
+Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-linux-py35.final.txt
+OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-osx-py35.final.txt
 ========  ======  ===
 
 2016.2
@@ -64,8 +64,8 @@ OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-osx-py
 ========  ======  ===
 PLATFORM  Python  URL
 ========  ======  ===
-Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2016.2/hstdp-2016.2-linux-py35.2.txt
-OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.2/hstdp-2016.2-osx-py35.2.txt
+Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2016.2/hstdp-2016.2-linux-py35.final.txt
+OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.2/hstdp-2016.2-osx-py35.final.txt
 ========  ======  ===
 
 2017.2
@@ -82,7 +82,7 @@ OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-osx-py
 Continuous Integration
 ======================
 
-This example BASH function is provided as a starting point for advanced users hooking up pipeline(s) in their continuous integration environments. This installation method is unsupported and your mileage may vary. Use at your own risk.
+This example BASH function is provided as a starting point for advanced users hooking up the pipeline(s) in their continuous integration environments. This installation method is unsupported and your mileage may vary. Use at your own risk.
 
 .. code-block:: sh
 

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -54,8 +54,8 @@ HST Data Processing (HSTDP)
 ========  ======  ===
 PLATFORM  Python  URL
 ========  ======  ===
-Linux     3.5     http://ssb.stsci.edu/conda/hstdp-2016.1/hstdp-2016.1-linux-py35.2.txt
-OS X      3.5     http://ssb.stsci.edu/conda/hstdp-2016.1/hstdp-2016.1-osx-py35.2.txt
+Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-linux-py35.2.txt
+OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-osx-py35.2.txt
 ========  ======  ===
 
 2016.2
@@ -64,8 +64,8 @@ OS X      3.5     http://ssb.stsci.edu/conda/hstdp-2016.1/hstdp-2016.1-osx-py35.
 ========  ======  ===
 PLATFORM  Python  URL
 ========  ======  ===
-Linux     3.5     http://ssb.stsci.edu/conda/hstdp-2016.2/hstdp-2016.2-linux-py35.2.txt
-OS X      3.5     http://ssb.stsci.edu/conda/hstdp-2016.2/hstdp-2016.2-osx-py35.2.txt
+Linux     3.5     http://ssb.stsci.edu/releases/hstdp/2016.2/hstdp-2016.2-linux-py35.2.txt
+OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2016.2/hstdp-2016.2-osx-py35.2.txt
 ========  ======  ===
 
 2017.2
@@ -79,19 +79,73 @@ OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-osx-py
 ========  ======  ===
 
 
-Release Schema
-==============
+Continuous Integration
+======================
 
-If you wish to write shell scripts to manage your local pipeline installations, this may be of interest to you:
+This example BASH function is provided as a starting point for advanced users hooking our pipeline(s) into their continuous integration environment. This installation method is unsupported and your mileage may vary. Use at your own risk.
 
 .. code-block:: sh
 
-    RELEASE_HOME=http://ssb.stsci.edu/releases
+    function get_pipeline()
+    {
+        # Do we have enough arguments?
+        if [[ $# < 3 ]]; then
+            echo "Not enough arguments."
+            return 1
+        fi
 
-    #               hstdp 2016  1
-    #               ^     ^     ^
-    RELEASE_PARENT=$NAME-$YEAR.$BUILD
+        # Setup basic argument list     & Example Input(s)
+        local conda_env="$1"            # hst_env
+        local name="$2"                 # hstdp, ...
+        local build="$3"                # 2017.2, 2016.2 ...
+        local python_version="$4"       # py[35, 27, ...]
+        local iteration="$5"            # final | post[0, 1, 2, ...]
 
-    #                              linux     py35            final|post#
-    #                              ^         ^               ^
-    RELEASE_CHILD=$RELEASE_PARENT-$PLATFORM-$PYTHON_VERSION.$ITERATION.txt
+        # Detect platform
+        local _platform=$(uname -s)
+        local platform=""
+
+        # Convert platform string to match file naming convention
+        if [[ ${_platform} == Linux ]]; then
+            platform="linux"
+        elif [[ ${_platform} == Darwin ]]; then
+            platform="osx"
+        else
+            echo "Unsupported platform: ${_platform}"
+            return 1
+        fi
+        unset _platform
+
+        # Handle optional arguments.
+        if [[ -z ${python_version} ]]; then
+            # Notice the "py" prefix and condensed version here
+            python_version="py35"
+        fi
+
+        if [[ -z ${iteration} ]]; then
+            iteration="final"
+        fi
+
+        # Assemble pipeline spec file URL
+        local ac_root="http://ssb.stsci.edu/releases"
+        local ac_base="${ac_root}/${name}/${build}"
+        local ac_spec="${name}-${build}-${platform}-${python_version}.${iteration}.txt"
+        local ac_url="${ac_base}/${ac_spec}"
+
+        # Perform installation
+        conda create -q -n "${conda_env}" --file "${ac_url}"
+        return $?
+    }
+
+    #
+    # Usage example:
+    #
+
+    # Silently generate a pipeline environment called "hst_env"
+    get_pipeline hst_env hstdp 2017.2
+
+    # Enter environment
+    source activate hst_env
+
+    # ... do work ...
+    # EOF

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -33,7 +33,7 @@ Example
         --file http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-linux-py35.0.txt
     source activate demo_2016.1
 
-The URL used here will not be updated to reflect the latest iteration available. Please consult the :ref:`files` section to ensure you are installing the correct release.
+The URL shown in this example does not necessarily reflect the latest iteration available. Please consult the :ref:`files` section to ensure you are installing the correct release.
 
 
 .. _files:

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -30,7 +30,7 @@ Example
 .. code-block:: sh
 
     conda create -n demo_2016.1 \
-        --file http://ssb.stsci.edu/conda/hstdp-2016.1/hstdp-2016.1-linux-py35.2.txt
+        --file http://ssb.stsci.edu/releases/hstdp/2016.1/hstdp-2016.1-linux-py35.0.txt
     source activate demo_2016.1
 
 The URL used here will not be updated to reflect the latest iteration available. Please consult the :ref:`files` section to ensure you are installing the correct release.

--- a/source/releases.rst
+++ b/source/releases.rst
@@ -82,7 +82,7 @@ OS X      3.5     http://ssb.stsci.edu/releases/hstdp/2017.2/hstdp-2017.2-osx-py
 Continuous Integration
 ======================
 
-This example BASH function is provided as a starting point for advanced users hooking up the pipeline(s) in their continuous integration environments. This installation method is unsupported and your mileage may vary. Use at your own risk.
+This example BASH function is provides a starting point for users intending to execute pipeline software from within a continuous integration environment. This installation method is unsupported and your mileage may vary. Use at your own risk.
 
 .. code-block:: sh
 


### PR DESCRIPTION
* Adds 2017.2 URLs
* Refactor URLs to use /releases/ rather than /conda/ (see: https://github.com/astroconda/astroconda-releases)
* Replaces "Release Schema" section with simple example script for CI users. Unsupported, but still potentially useful.
* Update compat page noting calcos release
