### PR TITLE
Added reference to conda-forge installation

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -1,4 +1,15 @@
 ##########################
+Install the default software stack via conda-forge
+##########################
+
+You can run the following command to install the software stack included in Astroconda using conda-forge:
+
+.. code-block:: sh
+
+    $ conda create -n astroconda --file [insert URL of conda environment YAML file here]
+    
+
+##########################
 Selecting a Software Stack
 ##########################
 


### PR DESCRIPTION
Since Astroconda will be no longer supported, the instructions now include a reference to a yaml file which will use the conda-forge channel to install the software stack included in Astroconda.